### PR TITLE
deprecated

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -75,7 +75,7 @@ class WidgetNumText extends StatelessWidget {
     final counter = Provider.of<Counter>(context);
     return Text(
       '${counter.value}',
-      style: Theme.of(context).textTheme.display1,
+      style: Theme.of(context).textTheme.headline4,
     );
   }
 }


### PR DESCRIPTION
This is the term used in the 2014 version of material design. The modern term is headline4. 
This feature was deprecated after v1.13.8.